### PR TITLE
Fixed reading from stdin

### DIFF
--- a/flake8_pep3101.py
+++ b/flake8_pep3101.py
@@ -15,7 +15,7 @@ class Flake8Pep3101(object):
 
     def run(self):
         if self.filename is 'stdin':
-            lines = pycodestyle.stdin_get_value().splitlines()
+            lines = pycodestyle.stdin_get_value()
             tree = ast.parse(lines)
         elif self.tree:
             tree = self.tree


### PR DESCRIPTION
Currently reading from stdin fails with the following error:
```
File "lib/python2.7/site-packages/flake8_pep3101.py", line 19, in run
    tree = ast.parse(lines)
  File "lib/python2.7/ast.py", line 37, in parse
    return compile(source, filename, mode, PyCF_ONLY_AST)
TypeError: expected a readable buffer object 
```

`ast.parse()` takes a string, rather than a list of strings, in both Python 2 and 3.