### PR TITLE
tests: Fix test_multiline_formatter

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -62,7 +62,7 @@ class TestFlake8Pep3101(unittest.TestCase):
             '% (\'world\'))',
         ]))
         app = application.Application()
-        with OutputCapture() as output:
+        with OutputCapture(fd=True) as output:
             app.run([file_path, ])
 
         self.assertIn(


### PR DESCRIPTION
This test fails with the latest version of flake8 because it tries to write to sys.stdout.buffer and the OutputCapture by default uses StringIO. This patch changes this specific test to use files instead.